### PR TITLE
Fix: getCurrentWeatherByGeoCoordinates from 'forecast' to 'weather'

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -49,7 +49,7 @@ class OpenWeatherMap extends OpenWeather {
         const currentWeather = (await this.getByGeoCoordinates({
           latitude,
           longitude,
-          queryType: FORECAST
+          queryType: WEATHER
         })) as CurrentResponse;
 
         resolve(currentWeather);


### PR DESCRIPTION
`getCurrentWeatherByGeoCoordinates` as of right now returns the forecast of the geocoords instead of the actual weather.

