### PR TITLE
Updated Types to include all API-Response-values

### DIFF
--- a/dist/types/CurrentReponse.d.ts
+++ b/dist/types/CurrentReponse.d.ts
@@ -17,11 +17,17 @@ declare const data: {
         temp_max: number;
         pressure: number;
         humidity: number;
+        sea_level: number;
+        grnd_level: number;
     };
     visibility: number;
     wind: {
         speed: number;
         deg: number;
+        gust: number;
+    };
+    rain: {
+        "1h": number;
     };
     clouds: {
         all: number;
@@ -39,8 +45,5 @@ declare const data: {
     name: string;
     cod: number;
 };
-declare type Visibility = {
-    visibility?: number;
-};
-export declare type CurrentResponse = typeof data & Visibility;
+export declare type CurrentResponse = typeof data;
 export {};

--- a/dist/types/CurrentReponse.js
+++ b/dist/types/CurrentReponse.js
@@ -1,47 +1,53 @@
 "use strict";
-// 20200516233806
-// https://openweathermap.org/data/2.5/weather?q=London,uk&appid=439d4b804bc8187953eb36d2a8c26a02
+// retrieved 03-14-2023
+// https://openweathermap.org/current
 Object.defineProperty(exports, "__esModule", { value: true });
 var data = {
-    coord: {
-        lon: -0.1257,
-        lat: 51.5085
+    "coord": {
+        "lon": 10.99,
+        "lat": 44.34
     },
-    weather: [
+    "weather": [
         {
-            id: 800,
-            main: 'Clear',
-            description: 'clear sky',
-            icon: '01d'
+            "id": 501,
+            "main": "Rain",
+            "description": "moderate rain",
+            "icon": "10d"
         }
     ],
-    base: 'stations',
-    main: {
-        temp: 23.6,
-        feels_like: 23.69,
-        temp_min: 18.92,
-        temp_max: 25.98,
-        pressure: 1028,
-        humidity: 64
+    "base": "stations",
+    "main": {
+        "temp": 298.48,
+        "feels_like": 298.74,
+        "temp_min": 297.56,
+        "temp_max": 300.05,
+        "pressure": 1015,
+        "humidity": 64,
+        "sea_level": 1015,
+        "grnd_level": 933
     },
-    visibility: 10000,
-    wind: {
-        speed: 4.12,
-        deg: 100
+    "visibility": 10000,
+    "wind": {
+        "speed": 0.62,
+        "deg": 349,
+        "gust": 1.18
     },
-    clouds: {
-        all: 0
+    "rain": {
+        "1h": 3.16
     },
-    dt: 1626552114,
-    sys: {
-        type: 2,
-        id: 268730,
-        country: 'GB',
-        sunrise: 1626494599,
-        sunset: 1626552575
+    "clouds": {
+        "all": 100
     },
-    timezone: 3600,
-    id: 2643743,
-    name: 'London',
-    cod: 200
+    "dt": 1661870592,
+    "sys": {
+        "type": 2,
+        "id": 2075663,
+        "country": "IT",
+        "sunrise": 1661834187,
+        "sunset": 1661882248
+    },
+    "timezone": 7200,
+    "id": 3163858,
+    "name": "Zocca",
+    "cod": 200
 };

--- a/dist/types/ThreeHourResponse.d.ts
+++ b/dist/types/ThreeHourResponse.d.ts
@@ -6,6 +6,7 @@ declare const data: {
         dt: number;
         main: {
             temp: number;
+            feels_like: number;
             temp_min: number;
             temp_max: number;
             pressure: number;
@@ -26,116 +27,51 @@ declare const data: {
         wind: {
             speed: number;
             deg: number;
+            gust: number;
         };
+        visibility: number;
+        pop: number;
+        rain: {
+            "3h": number;
+        };
+        sys: {
+            pod: string;
+        };
+        dt_txt: string;
+    } | {
+        dt: number;
+        main: {
+            temp: number;
+            feels_like: number;
+            temp_min: number;
+            temp_max: number;
+            pressure: number;
+            sea_level: number;
+            grnd_level: number;
+            humidity: number;
+            temp_kf: number;
+        };
+        weather: {
+            id: number;
+            main: string;
+            description: string;
+            icon: string;
+        }[];
+        clouds: {
+            all: number;
+        };
+        wind: {
+            speed: number;
+            deg: number;
+            gust: number;
+        };
+        visibility: number;
+        pop: number;
         sys: {
             pod: string;
         };
         dt_txt: string;
         rain?: undefined;
-        snow?: undefined;
-    } | {
-        dt: number;
-        main: {
-            temp: number;
-            temp_min: number;
-            temp_max: number;
-            pressure: number;
-            sea_level: number;
-            grnd_level: number;
-            humidity: number;
-            temp_kf: number;
-        };
-        weather: {
-            id: number;
-            main: string;
-            description: string;
-            icon: string;
-        }[];
-        clouds: {
-            all: number;
-        };
-        wind: {
-            speed: number;
-            deg: number;
-        };
-        rain: {
-            '3h': number;
-        };
-        sys: {
-            pod: string;
-        };
-        dt_txt: string;
-        snow?: undefined;
-    } | {
-        dt: number;
-        main: {
-            temp: number;
-            temp_min: number;
-            temp_max: number;
-            pressure: number;
-            sea_level: number;
-            grnd_level: number;
-            humidity: number;
-            temp_kf: number;
-        };
-        weather: {
-            id: number;
-            main: string;
-            description: string;
-            icon: string;
-        }[];
-        clouds: {
-            all: number;
-        };
-        wind: {
-            speed: number;
-            deg: number;
-        };
-        rain: {
-            '3h': number;
-        };
-        snow: {
-            '3h': number;
-        };
-        sys: {
-            pod: string;
-        };
-        dt_txt: string;
-    } | {
-        dt: number;
-        main: {
-            temp: number;
-            temp_min: number;
-            temp_max: number;
-            pressure: number;
-            sea_level: number;
-            grnd_level: number;
-            humidity: number;
-            temp_kf: number;
-        };
-        weather: {
-            id: number;
-            main: string;
-            description: string;
-            icon: string;
-        }[];
-        clouds: {
-            all: number;
-        };
-        wind: {
-            speed: number;
-            deg: number;
-        };
-        rain: {
-            '3h'?: undefined;
-        };
-        snow: {
-            '3h'?: undefined;
-        };
-        sys: {
-            pod: string;
-        };
-        dt_txt: string;
     })[];
     city: {
         id: number;
@@ -145,6 +81,10 @@ declare const data: {
             lon: number;
         };
         country: string;
+        population: number;
+        timezone: number;
+        sunrise: number;
+        sunset: number;
     };
 };
 export declare type ThreeHourResponse = typeof data;

--- a/dist/types/ThreeHourResponse.js
+++ b/dist/types/ThreeHourResponse.js
@@ -1,1263 +1,177 @@
 "use strict";
-// 20200512123825
-// https://samples.openweathermap.org/data/2.5/forecast?q=M%C3%BCnchen,DE&appid=439d4b804bc8187953eb36d2a8c26a02
+// retrieved 03-14-2023
+// https://openweathermap.org/forecast5
 Object.defineProperty(exports, "__esModule", { value: true });
 var data = {
-    cod: '200',
-    message: 0.0032,
-    cnt: 36,
-    list: [
+    "cod": "200",
+    "message": 0,
+    "cnt": 40,
+    "list": [
         {
-            dt: 1487246400,
-            main: {
-                temp: 286.67,
-                temp_min: 281.556,
-                temp_max: 286.67,
-                pressure: 972.73,
-                sea_level: 1046.46,
-                grnd_level: 972.73,
-                humidity: 75,
-                temp_kf: 5.11,
+            "dt": 1661871600,
+            "main": {
+                "temp": 296.76,
+                "feels_like": 296.98,
+                "temp_min": 296.76,
+                "temp_max": 297.87,
+                "pressure": 1015,
+                "sea_level": 1015,
+                "grnd_level": 933,
+                "humidity": 69,
+                "temp_kf": -1.11
             },
-            weather: [
+            "weather": [
                 {
-                    id: 800,
-                    main: 'Clear',
-                    description: 'clear sky',
-                    icon: '01d',
-                },
+                    "id": 500,
+                    "main": "Rain",
+                    "description": "light rain",
+                    "icon": "10d"
+                }
             ],
-            clouds: {
-                all: 0,
+            "clouds": {
+                "all": 100
             },
-            wind: {
-                speed: 1.81,
-                deg: 247.501,
+            "wind": {
+                "speed": 0.62,
+                "deg": 349,
+                "gust": 1.18
             },
-            sys: {
-                pod: 'd',
+            "visibility": 10000,
+            "pop": 0.32,
+            "rain": {
+                "3h": 0.26
             },
-            dt_txt: '2017-02-16 12:00:00',
+            "sys": {
+                "pod": "d"
+            },
+            "dt_txt": "2022-08-30 15:00:00"
         },
         {
-            dt: 1487257200,
-            main: {
-                temp: 285.66,
-                temp_min: 281.821,
-                temp_max: 285.66,
-                pressure: 970.91,
-                sea_level: 1044.32,
-                grnd_level: 970.91,
-                humidity: 70,
-                temp_kf: 3.84,
+            "dt": 1661882400,
+            "main": {
+                "temp": 295.45,
+                "feels_like": 295.59,
+                "temp_min": 292.84,
+                "temp_max": 295.45,
+                "pressure": 1015,
+                "sea_level": 1015,
+                "grnd_level": 931,
+                "humidity": 71,
+                "temp_kf": 2.61
             },
-            weather: [
+            "weather": [
                 {
-                    id: 800,
-                    main: 'Clear',
-                    description: 'clear sky',
-                    icon: '01d',
-                },
+                    "id": 500,
+                    "main": "Rain",
+                    "description": "light rain",
+                    "icon": "10n"
+                }
             ],
-            clouds: {
-                all: 0,
+            "clouds": {
+                "all": 96
             },
-            wind: {
-                speed: 1.59,
-                deg: 290.501,
+            "wind": {
+                "speed": 1.97,
+                "deg": 157,
+                "gust": 3.39
             },
-            sys: {
-                pod: 'd',
+            "visibility": 10000,
+            "pop": 0.33,
+            "rain": {
+                "3h": 0.57
             },
-            dt_txt: '2017-02-16 15:00:00',
+            "sys": {
+                "pod": "n"
+            },
+            "dt_txt": "2022-08-30 18:00:00"
         },
         {
-            dt: 1487268000,
-            main: {
-                temp: 277.05,
-                temp_min: 274.498,
-                temp_max: 277.05,
-                pressure: 970.44,
-                sea_level: 1044.7,
-                grnd_level: 970.44,
-                humidity: 90,
-                temp_kf: 2.56,
+            "dt": 1661893200,
+            "main": {
+                "temp": 292.46,
+                "feels_like": 292.54,
+                "temp_min": 290.31,
+                "temp_max": 292.46,
+                "pressure": 1015,
+                "sea_level": 1015,
+                "grnd_level": 931,
+                "humidity": 80,
+                "temp_kf": 2.15
             },
-            weather: [
+            "weather": [
                 {
-                    id: 800,
-                    main: 'Clear',
-                    description: 'clear sky',
-                    icon: '01n',
-                },
+                    "id": 500,
+                    "main": "Rain",
+                    "description": "light rain",
+                    "icon": "10n"
+                }
             ],
-            clouds: {
-                all: 0,
+            "clouds": {
+                "all": 68
             },
-            wind: {
-                speed: 1.41,
-                deg: 263.5,
+            "wind": {
+                "speed": 2.66,
+                "deg": 210,
+                "gust": 3.58
             },
-            sys: {
-                pod: 'n',
+            "visibility": 10000,
+            "pop": 0.7,
+            "rain": {
+                "3h": 0.49
             },
-            dt_txt: '2017-02-16 18:00:00',
+            "sys": {
+                "pod": "n"
+            },
+            "dt_txt": "2022-08-30 21:00:00"
         },
         {
-            dt: 1487278800,
-            main: {
-                temp: 272.78,
-                temp_min: 271.503,
-                temp_max: 272.78,
-                pressure: 969.32,
-                sea_level: 1044.14,
-                grnd_level: 969.32,
-                humidity: 80,
-                temp_kf: 1.28,
+            "dt": 1662292800,
+            "main": {
+                "temp": 294.93,
+                "feels_like": 294.83,
+                "temp_min": 294.93,
+                "temp_max": 294.93,
+                "pressure": 1018,
+                "sea_level": 1018,
+                "grnd_level": 935,
+                "humidity": 64,
+                "temp_kf": 0
             },
-            weather: [
+            "weather": [
                 {
-                    id: 800,
-                    main: 'Clear',
-                    description: 'clear sky',
-                    icon: '01n',
-                },
+                    "id": 804,
+                    "main": "Clouds",
+                    "description": "overcast clouds",
+                    "icon": "04d"
+                }
             ],
-            clouds: {
-                all: 0,
-            },
-            wind: {
-                speed: 2.24,
-                deg: 205.502,
-            },
-            sys: {
-                pod: 'n',
-            },
-            dt_txt: '2017-02-16 21:00:00',
-        },
-        {
-            dt: 1487289600,
-            main: {
-                temp: 273.341,
-                temp_min: 273.341,
-                temp_max: 273.341,
-                pressure: 968.14,
-                sea_level: 1042.96,
-                grnd_level: 968.14,
-                humidity: 85,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 803,
-                    main: 'Clouds',
-                    description: 'broken clouds',
-                    icon: '04n',
-                },
-            ],
-            clouds: {
-                all: 76,
-            },
-            wind: {
-                speed: 3.59,
-                deg: 224.003,
-            },
-            sys: {
-                pod: 'n',
-            },
-            dt_txt: '2017-02-17 00:00:00',
-        },
-        {
-            dt: 1487300400,
-            main: {
-                temp: 275.568,
-                temp_min: 275.568,
-                temp_max: 275.568,
-                pressure: 966.6,
-                sea_level: 1041.39,
-                grnd_level: 966.6,
-                humidity: 89,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 500,
-                    main: 'Rain',
-                    description: 'light rain',
-                    icon: '10n',
-                },
-            ],
-            clouds: {
-                all: 76,
-            },
-            wind: {
-                speed: 3.77,
-                deg: 237.002,
-            },
-            rain: {
-                '3h': 0.32,
-            },
-            sys: {
-                pod: 'n',
-            },
-            dt_txt: '2017-02-17 03:00:00',
-        },
-        {
-            dt: 1487311200,
-            main: {
-                temp: 276.478,
-                temp_min: 276.478,
-                temp_max: 276.478,
-                pressure: 966.45,
-                sea_level: 1041.21,
-                grnd_level: 966.45,
-                humidity: 97,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 501,
-                    main: 'Rain',
-                    description: 'moderate rain',
-                    icon: '10n',
-                },
-            ],
-            clouds: {
-                all: 92,
-            },
-            wind: {
-                speed: 3.81,
-                deg: 268.005,
-            },
-            rain: {
-                '3h': 4.9,
-            },
-            sys: {
-                pod: 'n',
-            },
-            dt_txt: '2017-02-17 06:00:00',
-        },
-        {
-            dt: 1487322000,
-            main: {
-                temp: 276.67,
-                temp_min: 276.67,
-                temp_max: 276.67,
-                pressure: 967.41,
-                sea_level: 1041.95,
-                grnd_level: 967.41,
-                humidity: 100,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 500,
-                    main: 'Rain',
-                    description: 'light rain',
-                    icon: '10d',
-                },
-            ],
-            clouds: {
-                all: 64,
-            },
-            wind: {
-                speed: 2.6,
-                deg: 266.504,
-            },
-            rain: {
-                '3h': 1.37,
-            },
-            sys: {
-                pod: 'd',
-            },
-            dt_txt: '2017-02-17 09:00:00',
-        },
-        {
-            dt: 1487332800,
-            main: {
-                temp: 278.253,
-                temp_min: 278.253,
-                temp_max: 278.253,
-                pressure: 966.98,
-                sea_level: 1040.89,
-                grnd_level: 966.98,
-                humidity: 95,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 500,
-                    main: 'Rain',
-                    description: 'light rain',
-                    icon: '10d',
-                },
-            ],
-            clouds: {
-                all: 92,
-            },
-            wind: {
-                speed: 3.17,
-                deg: 261.501,
-            },
-            rain: {
-                '3h': 0.12,
-            },
-            sys: {
-                pod: 'd',
-            },
-            dt_txt: '2017-02-17 12:00:00',
-        },
-        {
-            dt: 1487343600,
-            main: {
-                temp: 276.455,
-                temp_min: 276.455,
-                temp_max: 276.455,
-                pressure: 966.38,
-                sea_level: 1040.17,
-                grnd_level: 966.38,
-                humidity: 99,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 500,
-                    main: 'Rain',
-                    description: 'light rain',
-                    icon: '10d',
-                },
-            ],
-            clouds: {
-                all: 92,
-            },
-            wind: {
-                speed: 3.21,
-                deg: 268.001,
-            },
-            rain: {
-                '3h': 2.12,
-            },
-            sys: {
-                pod: 'd',
-            },
-            dt_txt: '2017-02-17 15:00:00',
-        },
-        {
-            dt: 1487354400,
-            main: {
-                temp: 275.639,
-                temp_min: 275.639,
-                temp_max: 275.639,
-                pressure: 966.39,
-                sea_level: 1040.65,
-                grnd_level: 966.39,
-                humidity: 95,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 500,
-                    main: 'Rain',
-                    description: 'light rain',
-                    icon: '10n',
-                },
-            ],
-            clouds: {
-                all: 88,
-            },
-            wind: {
-                speed: 3.17,
-                deg: 258.001,
-            },
-            rain: {
-                '3h': 0.7,
-            },
-            snow: {
-                '3h': 0.0775,
-            },
-            sys: {
-                pod: 'n',
-            },
-            dt_txt: '2017-02-17 18:00:00',
-        },
-        {
-            dt: 1487365200,
-            main: {
-                temp: 275.459,
-                temp_min: 275.459,
-                temp_max: 275.459,
-                pressure: 966.3,
-                sea_level: 1040.8,
-                grnd_level: 966.3,
-                humidity: 96,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 500,
-                    main: 'Rain',
-                    description: 'light rain',
-                    icon: '10n',
-                },
-            ],
-            clouds: {
-                all: 88,
-            },
-            wind: {
-                speed: 3.71,
-                deg: 265.503,
-            },
-            rain: {
-                '3h': 1.16,
-            },
-            snow: {
-                '3h': 0.075,
-            },
-            sys: {
-                pod: 'n',
-            },
-            dt_txt: '2017-02-17 21:00:00',
-        },
-        {
-            dt: 1487376000,
-            main: {
-                temp: 275.035,
-                temp_min: 275.035,
-                temp_max: 275.035,
-                pressure: 966.43,
-                sea_level: 1041.02,
-                grnd_level: 966.43,
-                humidity: 99,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 500,
-                    main: 'Rain',
-                    description: 'light rain',
-                    icon: '10n',
-                },
-            ],
-            clouds: {
-                all: 92,
-            },
-            wind: {
-                speed: 3.56,
-                deg: 273.5,
-            },
-            rain: {
-                '3h': 1.37,
-            },
-            snow: {
-                '3h': 0.1525,
-            },
-            sys: {
-                pod: 'n',
-            },
-            dt_txt: '2017-02-18 00:00:00',
-        },
-        {
-            dt: 1487386800,
-            main: {
-                temp: 274.965,
-                temp_min: 274.965,
-                temp_max: 274.965,
-                pressure: 966.36,
-                sea_level: 1041.17,
-                grnd_level: 966.36,
-                humidity: 97,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 500,
-                    main: 'Rain',
-                    description: 'light rain',
-                    icon: '10n',
-                },
-            ],
-            clouds: {
-                all: 88,
-            },
-            wind: {
-                speed: 2.66,
-                deg: 285.502,
-            },
-            rain: {
-                '3h': 0.79,
-            },
-            snow: {
-                '3h': 0.52,
-            },
-            sys: {
-                pod: 'n',
-            },
-            dt_txt: '2017-02-18 03:00:00',
-        },
-        {
-            dt: 1487397600,
-            main: {
-                temp: 274.562,
-                temp_min: 274.562,
-                temp_max: 274.562,
-                pressure: 966.75,
-                sea_level: 1041.57,
-                grnd_level: 966.75,
-                humidity: 98,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 500,
-                    main: 'Rain',
-                    description: 'light rain',
-                    icon: '10n',
-                },
-            ],
-            clouds: {
-                all: 88,
-            },
-            wind: {
-                speed: 1.46,
-                deg: 276.5,
-            },
-            rain: {
-                '3h': 0.08,
-            },
-            snow: {
-                '3h': 0.06,
-            },
-            sys: {
-                pod: 'n',
-            },
-            dt_txt: '2017-02-18 06:00:00',
-        },
-        {
-            dt: 1487408400,
-            main: {
-                temp: 275.648,
-                temp_min: 275.648,
-                temp_max: 275.648,
-                pressure: 967.21,
-                sea_level: 1041.74,
-                grnd_level: 967.21,
-                humidity: 99,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 500,
-                    main: 'Rain',
-                    description: 'light rain',
-                    icon: '10d',
-                },
-            ],
-            clouds: {
-                all: 56,
-            },
-            wind: {
-                speed: 1.5,
-                deg: 251.008,
-            },
-            rain: {
-                '3h': 0.02,
-            },
-            snow: {
-                '3h': 0.03,
-            },
-            sys: {
-                pod: 'd',
-            },
-            dt_txt: '2017-02-18 09:00:00',
-        },
-        {
-            dt: 1487419200,
-            main: {
-                temp: 277.927,
-                temp_min: 277.927,
-                temp_max: 277.927,
-                pressure: 966.06,
-                sea_level: 1039.98,
-                grnd_level: 966.06,
-                humidity: 95,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 800,
-                    main: 'Clear',
-                    description: 'clear sky',
-                    icon: '02d',
-                },
-            ],
-            clouds: {
-                all: 8,
-            },
-            wind: {
-                speed: 0.86,
-                deg: 244.004,
-            },
-            rain: {},
-            snow: {},
-            sys: {
-                pod: 'd',
-            },
-            dt_txt: '2017-02-18 12:00:00',
-        },
-        {
-            dt: 1487430000,
-            main: {
-                temp: 278.367,
-                temp_min: 278.367,
-                temp_max: 278.367,
-                pressure: 964.57,
-                sea_level: 1038.35,
-                grnd_level: 964.57,
-                humidity: 89,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 800,
-                    main: 'Clear',
-                    description: 'clear sky',
-                    icon: '02d',
-                },
-            ],
-            clouds: {
-                all: 8,
-            },
-            wind: {
-                speed: 1.62,
-                deg: 79.5024,
-            },
-            rain: {},
-            snow: {},
-            sys: {
-                pod: 'd',
-            },
-            dt_txt: '2017-02-18 15:00:00',
-        },
-        {
-            dt: 1487440800,
-            main: {
-                temp: 273.797,
-                temp_min: 273.797,
-                temp_max: 273.797,
-                pressure: 964.13,
-                sea_level: 1038.48,
-                grnd_level: 964.13,
-                humidity: 91,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 800,
-                    main: 'Clear',
-                    description: 'clear sky',
-                    icon: '01n',
-                },
-            ],
-            clouds: {
-                all: 0,
-            },
-            wind: {
-                speed: 2.42,
-                deg: 77.0026,
-            },
-            rain: {},
-            snow: {},
-            sys: {
-                pod: 'n',
-            },
-            dt_txt: '2017-02-18 18:00:00',
-        },
-        {
-            dt: 1487451600,
-            main: {
-                temp: 271.239,
-                temp_min: 271.239,
-                temp_max: 271.239,
-                pressure: 963.39,
-                sea_level: 1038.21,
-                grnd_level: 963.39,
-                humidity: 93,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 800,
-                    main: 'Clear',
-                    description: 'clear sky',
-                    icon: '01n',
-                },
-            ],
-            clouds: {
-                all: 0,
-            },
-            wind: {
-                speed: 2.42,
-                deg: 95.5017,
-            },
-            rain: {},
-            snow: {},
-            sys: {
-                pod: 'n',
-            },
-            dt_txt: '2017-02-18 21:00:00',
-        },
-        {
-            dt: 1487462400,
-            main: {
-                temp: 269.553,
-                temp_min: 269.553,
-                temp_max: 269.553,
-                pressure: 962.39,
-                sea_level: 1037.44,
-                grnd_level: 962.39,
-                humidity: 92,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 800,
-                    main: 'Clear',
-                    description: 'clear sky',
-                    icon: '01n',
-                },
-            ],
-            clouds: {
-                all: 0,
-            },
-            wind: {
-                speed: 1.96,
-                deg: 101.004,
-            },
-            rain: {},
-            snow: {},
-            sys: {
-                pod: 'n',
-            },
-            dt_txt: '2017-02-19 00:00:00',
-        },
-        {
-            dt: 1487473200,
-            main: {
-                temp: 268.198,
-                temp_min: 268.198,
-                temp_max: 268.198,
-                pressure: 961.28,
-                sea_level: 1036.51,
-                grnd_level: 961.28,
-                humidity: 84,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 800,
-                    main: 'Clear',
-                    description: 'clear sky',
-                    icon: '01n',
-                },
-            ],
-            clouds: {
-                all: 0,
-            },
-            wind: {
-                speed: 1.06,
-                deg: 121.5,
-            },
-            rain: {},
-            snow: {},
-            sys: {
-                pod: 'n',
-            },
-            dt_txt: '2017-02-19 03:00:00',
-        },
-        {
-            dt: 1487484000,
-            main: {
-                temp: 267.295,
-                temp_min: 267.295,
-                temp_max: 267.295,
-                pressure: 961.16,
-                sea_level: 1036.45,
-                grnd_level: 961.16,
-                humidity: 86,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 800,
-                    main: 'Clear',
-                    description: 'clear sky',
-                    icon: '01n',
-                },
-            ],
-            clouds: {
-                all: 0,
-            },
-            wind: {
-                speed: 1.17,
-                deg: 155.005,
-            },
-            rain: {},
-            snow: {},
-            sys: {
-                pod: 'n',
-            },
-            dt_txt: '2017-02-19 06:00:00',
-        },
-        {
-            dt: 1487494800,
-            main: {
-                temp: 272.956,
-                temp_min: 272.956,
-                temp_max: 272.956,
-                pressure: 962.03,
-                sea_level: 1036.85,
-                grnd_level: 962.03,
-                humidity: 84,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 800,
-                    main: 'Clear',
-                    description: 'clear sky',
-                    icon: '01d',
-                },
-            ],
-            clouds: {
-                all: 0,
-            },
-            wind: {
-                speed: 1.66,
-                deg: 195.002,
-            },
-            rain: {},
-            snow: {},
-            sys: {
-                pod: 'd',
-            },
-            dt_txt: '2017-02-19 09:00:00',
-        },
-        {
-            dt: 1487505600,
-            main: {
-                temp: 277.422,
-                temp_min: 277.422,
-                temp_max: 277.422,
-                pressure: 962.23,
-                sea_level: 1036.06,
-                grnd_level: 962.23,
-                humidity: 89,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 800,
-                    main: 'Clear',
-                    description: 'clear sky',
-                    icon: '01d',
-                },
-            ],
-            clouds: {
-                all: 0,
-            },
-            wind: {
-                speed: 1.32,
-                deg: 357.003,
-            },
-            rain: {},
-            snow: {},
-            sys: {
-                pod: 'd',
-            },
-            dt_txt: '2017-02-19 12:00:00',
-        },
-        {
-            dt: 1487516400,
-            main: {
-                temp: 277.984,
-                temp_min: 277.984,
-                temp_max: 277.984,
-                pressure: 962.15,
-                sea_level: 1035.86,
-                grnd_level: 962.15,
-                humidity: 87,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 800,
-                    main: 'Clear',
-                    description: 'clear sky',
-                    icon: '01d',
-                },
-            ],
-            clouds: {
-                all: 0,
-            },
-            wind: {
-                speed: 1.58,
-                deg: 48.5031,
-            },
-            rain: {},
-            snow: {},
-            sys: {
-                pod: 'd',
-            },
-            dt_txt: '2017-02-19 15:00:00',
-        },
-        {
-            dt: 1487527200,
-            main: {
-                temp: 272.459,
-                temp_min: 272.459,
-                temp_max: 272.459,
-                pressure: 963.31,
-                sea_level: 1037.81,
-                grnd_level: 963.31,
-                humidity: 90,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 800,
-                    main: 'Clear',
-                    description: 'clear sky',
-                    icon: '01n',
-                },
-            ],
-            clouds: {
-                all: 0,
-            },
-            wind: {
-                speed: 1.16,
-                deg: 75.5042,
-            },
-            rain: {},
-            snow: {},
-            sys: {
-                pod: 'n',
-            },
-            dt_txt: '2017-02-19 18:00:00',
-        },
-        {
-            dt: 1487538000,
-            main: {
-                temp: 269.473,
-                temp_min: 269.473,
-                temp_max: 269.473,
-                pressure: 964.65,
-                sea_level: 1039.76,
-                grnd_level: 964.65,
-                humidity: 83,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 800,
-                    main: 'Clear',
-                    description: 'clear sky',
-                    icon: '01n',
-                },
-            ],
-            clouds: {
-                all: 0,
-            },
-            wind: {
-                speed: 1.12,
-                deg: 174.002,
-            },
-            rain: {},
-            snow: {},
-            sys: {
-                pod: 'n',
-            },
-            dt_txt: '2017-02-19 21:00:00',
-        },
-        {
-            dt: 1487548800,
-            main: {
-                temp: 268.793,
-                temp_min: 268.793,
-                temp_max: 268.793,
-                pressure: 965.92,
-                sea_level: 1041.32,
-                grnd_level: 965.92,
-                humidity: 80,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 800,
-                    main: 'Clear',
-                    description: 'clear sky',
-                    icon: '01n',
-                },
-            ],
-            clouds: {
-                all: 0,
-            },
-            wind: {
-                speed: 2.11,
-                deg: 207.502,
-            },
-            rain: {},
-            snow: {},
-            sys: {
-                pod: 'n',
-            },
-            dt_txt: '2017-02-20 00:00:00',
-        },
-        {
-            dt: 1487559600,
-            main: {
-                temp: 268.106,
-                temp_min: 268.106,
-                temp_max: 268.106,
-                pressure: 966.4,
-                sea_level: 1042.18,
-                grnd_level: 966.4,
-                humidity: 85,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 800,
-                    main: 'Clear',
-                    description: 'clear sky',
-                    icon: '01n',
-                },
-            ],
-            clouds: {
-                all: 0,
-            },
-            wind: {
-                speed: 1.67,
-                deg: 191.001,
-            },
-            rain: {},
-            snow: {},
-            sys: {
-                pod: 'n',
-            },
-            dt_txt: '2017-02-20 03:00:00',
-        },
-        {
-            dt: 1487570400,
-            main: {
-                temp: 267.655,
-                temp_min: 267.655,
-                temp_max: 267.655,
-                pressure: 967.4,
-                sea_level: 1043.43,
-                grnd_level: 967.4,
-                humidity: 84,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 800,
-                    main: 'Clear',
-                    description: 'clear sky',
-                    icon: '01n',
-                },
-            ],
-            clouds: {
-                all: 0,
-            },
-            wind: {
-                speed: 1.61,
-                deg: 194.001,
-            },
-            rain: {},
-            snow: {},
-            sys: {
-                pod: 'n',
-            },
-            dt_txt: '2017-02-20 06:00:00',
-        },
-        {
-            dt: 1487581200,
-            main: {
-                temp: 273.75,
-                temp_min: 273.75,
-                temp_max: 273.75,
-                pressure: 968.84,
-                sea_level: 1044.23,
-                grnd_level: 968.84,
-                humidity: 83,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 800,
-                    main: 'Clear',
-                    description: 'clear sky',
-                    icon: '01d',
-                },
-            ],
-            clouds: {
-                all: 0,
-            },
-            wind: {
-                speed: 2.49,
-                deg: 208.5,
-            },
-            rain: {},
-            snow: {},
-            sys: {
-                pod: 'd',
-            },
-            dt_txt: '2017-02-20 09:00:00',
-        },
-        {
-            dt: 1487592000,
-            main: {
-                temp: 279.302,
-                temp_min: 279.302,
-                temp_max: 279.302,
-                pressure: 968.37,
-                sea_level: 1042.52,
-                grnd_level: 968.37,
-                humidity: 83,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 800,
-                    main: 'Clear',
-                    description: 'clear sky',
-                    icon: '01d',
-                },
-            ],
-            clouds: {
-                all: 0,
-            },
-            wind: {
-                speed: 2.46,
-                deg: 252.001,
-            },
-            rain: {},
-            snow: {},
-            sys: {
-                pod: 'd',
-            },
-            dt_txt: '2017-02-20 12:00:00',
-        },
-        {
-            dt: 1487602800,
-            main: {
-                temp: 279.343,
-                temp_min: 279.343,
-                temp_max: 279.343,
-                pressure: 967.9,
-                sea_level: 1041.64,
-                grnd_level: 967.9,
-                humidity: 81,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 800,
-                    main: 'Clear',
-                    description: 'clear sky',
-                    icon: '01d',
-                },
-            ],
-            clouds: {
-                all: 0,
-            },
-            wind: {
-                speed: 3.21,
-                deg: 268.001,
-            },
-            rain: {},
-            snow: {},
-            sys: {
-                pod: 'd',
-            },
-            dt_txt: '2017-02-20 15:00:00',
-        },
-        {
-            dt: 1487613600,
-            main: {
-                temp: 274.443,
-                temp_min: 274.443,
-                temp_max: 274.443,
-                pressure: 968.19,
-                sea_level: 1042.66,
-                grnd_level: 968.19,
-                humidity: 88,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 801,
-                    main: 'Clouds',
-                    description: 'few clouds',
-                    icon: '02n',
-                },
-            ],
-            clouds: {
-                all: 24,
-            },
-            wind: {
-                speed: 3.27,
-                deg: 257.501,
-            },
-            rain: {},
-            snow: {},
-            sys: {
-                pod: 'n',
-            },
-            dt_txt: '2017-02-20 18:00:00',
-        },
-        {
-            dt: 1487624400,
-            main: {
-                temp: 272.424,
-                temp_min: 272.424,
-                temp_max: 272.424,
-                pressure: 968.38,
-                sea_level: 1043.17,
-                grnd_level: 968.38,
-                humidity: 85,
-                temp_kf: 0,
-            },
-            weather: [
-                {
-                    id: 801,
-                    main: 'Clouds',
-                    description: 'few clouds',
-                    icon: '02n',
-                },
-            ],
-            clouds: {
-                all: 20,
-            },
-            wind: {
-                speed: 3.57,
-                deg: 255.503,
-            },
-            rain: {},
-            snow: {},
-            sys: {
-                pod: 'n',
-            },
-            dt_txt: '2017-02-20 21:00:00',
-        },
+            "clouds": {
+                "all": 88
+            },
+            "wind": {
+                "speed": 1.14,
+                "deg": 17,
+                "gust": 1.57
+            },
+            "visibility": 10000,
+            "pop": 0,
+            "sys": {
+                "pod": "d"
+            },
+            "dt_txt": "2022-09-04 12:00:00"
+        }
     ],
-    city: {
-        id: 6940463,
-        name: 'Altstadt',
-        coord: {
-            lat: 48.137,
-            lon: 11.5752,
+    "city": {
+        "id": 3163858,
+        "name": "Zocca",
+        "coord": {
+            "lat": 44.34,
+            "lon": 10.99
         },
-        country: 'none',
-    },
+        "country": "IT",
+        "population": 4593,
+        "timezone": 7200,
+        "sunrise": 1661834187,
+        "sunset": 1661882248
+    }
 };

--- a/src/types/CurrentReponse.ts
+++ b/src/types/CurrentReponse.ts
@@ -1,52 +1,55 @@
-// 20200516233806
-// https://openweathermap.org/data/2.5/weather?q=London,uk&appid=439d4b804bc8187953eb36d2a8c26a02
+// retrieved 03-14-2023
+// https://openweathermap.org/current
 
-const data = {
-  coord: {
-    lon: -0.1257,
-    lat: 51.5085
+const data =
+{
+  "coord": {
+    "lon": 10.99,
+    "lat": 44.34
   },
-  weather: [
+  "weather": [
     {
-      id: 800,
-      main: 'Clear',
-      description: 'clear sky',
-      icon: '01d'
+      "id": 501,
+      "main": "Rain",
+      "description": "moderate rain",
+      "icon": "10d"
     }
   ],
-  base: 'stations',
-  main: {
-    temp: 23.6,
-    feels_like: 23.69,
-    temp_min: 18.92,
-    temp_max: 25.98,
-    pressure: 1028,
-    humidity: 64
+  "base": "stations",
+  "main": {
+    "temp": 298.48,
+    "feels_like": 298.74,
+    "temp_min": 297.56,
+    "temp_max": 300.05,
+    "pressure": 1015,
+    "humidity": 64,
+    "sea_level": 1015,
+    "grnd_level": 933
   },
-  visibility: 10000,
-  wind: {
-    speed: 4.12,
-    deg: 100
+  "visibility": 10000,
+  "wind": {
+    "speed": 0.62,
+    "deg": 349,
+    "gust": 1.18
   },
-  clouds: {
-    all: 0
+  "rain": {
+    "1h": 3.16
   },
-  dt: 1626552114,
-  sys: {
-    type: 2,
-    id: 268730,
-    country: 'GB',
-    sunrise: 1626494599,
-    sunset: 1626552575
+  "clouds": {
+    "all": 100
   },
-  timezone: 3600,
-  id: 2643743,
-  name: 'London',
-  cod: 200
-};
+  "dt": 1661870592,
+  "sys": {
+    "type": 2,
+    "id": 2075663,
+    "country": "IT",
+    "sunrise": 1661834187,
+    "sunset": 1661882248
+  },
+  "timezone": 7200,
+  "id": 3163858,
+  "name": "Zocca",
+  "cod": 200
+};      
 
-type Visibility = {
-  visibility?: number;
-};
-
-export type CurrentResponse = typeof data & Visibility;
+export type CurrentResponse = typeof data;

--- a/src/types/ThreeHourResponse.ts
+++ b/src/types/ThreeHourResponse.ts
@@ -1,1264 +1,179 @@
-// 20200512123825
-// https://samples.openweathermap.org/data/2.5/forecast?q=M%C3%BCnchen,DE&appid=439d4b804bc8187953eb36d2a8c26a02
+// retrieved 03-14-2023
+// https://openweathermap.org/forecast5
 
-const data = {
-  cod: '200',
-  message: 0.0032,
-  cnt: 36,
-  list: [
+const data =
+{
+  "cod": "200",
+  "message": 0,
+  "cnt": 40,
+  "list": [
     {
-      dt: 1487246400,
-      main: {
-        temp: 286.67,
-        temp_min: 281.556,
-        temp_max: 286.67,
-        pressure: 972.73,
-        sea_level: 1046.46,
-        grnd_level: 972.73,
-        humidity: 75,
-        temp_kf: 5.11,
+      "dt": 1661871600,
+      "main": {
+        "temp": 296.76,
+        "feels_like": 296.98,
+        "temp_min": 296.76,
+        "temp_max": 297.87,
+        "pressure": 1015,
+        "sea_level": 1015,
+        "grnd_level": 933,
+        "humidity": 69,
+        "temp_kf": -1.11
       },
-      weather: [
+      "weather": [
         {
-          id: 800,
-          main: 'Clear',
-          description: 'clear sky',
-          icon: '01d',
-        },
+          "id": 500,
+          "main": "Rain",
+          "description": "light rain",
+          "icon": "10d"
+        }
       ],
-      clouds: {
-        all: 0,
+      "clouds": {
+        "all": 100
       },
-      wind: {
-        speed: 1.81,
-        deg: 247.501,
+      "wind": {
+        "speed": 0.62,
+        "deg": 349,
+        "gust": 1.18
       },
-      sys: {
-        pod: 'd',
+      "visibility": 10000,
+      "pop": 0.32,
+      "rain": {
+        "3h": 0.26
       },
-      dt_txt: '2017-02-16 12:00:00',
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2022-08-30 15:00:00"
     },
     {
-      dt: 1487257200,
-      main: {
-        temp: 285.66,
-        temp_min: 281.821,
-        temp_max: 285.66,
-        pressure: 970.91,
-        sea_level: 1044.32,
-        grnd_level: 970.91,
-        humidity: 70,
-        temp_kf: 3.84,
+      "dt": 1661882400,
+      "main": {
+        "temp": 295.45,
+        "feels_like": 295.59,
+        "temp_min": 292.84,
+        "temp_max": 295.45,
+        "pressure": 1015,
+        "sea_level": 1015,
+        "grnd_level": 931,
+        "humidity": 71,
+        "temp_kf": 2.61
       },
-      weather: [
+      "weather": [
         {
-          id: 800,
-          main: 'Clear',
-          description: 'clear sky',
-          icon: '01d',
-        },
+          "id": 500,
+          "main": "Rain",
+          "description": "light rain",
+          "icon": "10n"
+        }
       ],
-      clouds: {
-        all: 0,
+      "clouds": {
+        "all": 96
       },
-      wind: {
-        speed: 1.59,
-        deg: 290.501,
+      "wind": {
+        "speed": 1.97,
+        "deg": 157,
+        "gust": 3.39
       },
-      sys: {
-        pod: 'd',
+      "visibility": 10000,
+      "pop": 0.33,
+      "rain": {
+        "3h": 0.57
       },
-      dt_txt: '2017-02-16 15:00:00',
+      "sys": {
+        "pod": "n"
+      },
+      "dt_txt": "2022-08-30 18:00:00"
     },
     {
-      dt: 1487268000,
-      main: {
-        temp: 277.05,
-        temp_min: 274.498,
-        temp_max: 277.05,
-        pressure: 970.44,
-        sea_level: 1044.7,
-        grnd_level: 970.44,
-        humidity: 90,
-        temp_kf: 2.56,
+      "dt": 1661893200,
+      "main": {
+        "temp": 292.46,
+        "feels_like": 292.54,
+        "temp_min": 290.31,
+        "temp_max": 292.46,
+        "pressure": 1015,
+        "sea_level": 1015,
+        "grnd_level": 931,
+        "humidity": 80,
+        "temp_kf": 2.15
       },
-      weather: [
+      "weather": [
         {
-          id: 800,
-          main: 'Clear',
-          description: 'clear sky',
-          icon: '01n',
-        },
+          "id": 500,
+          "main": "Rain",
+          "description": "light rain",
+          "icon": "10n"
+        }
       ],
-      clouds: {
-        all: 0,
+      "clouds": {
+        "all": 68
       },
-      wind: {
-        speed: 1.41,
-        deg: 263.5,
+      "wind": {
+        "speed": 2.66,
+        "deg": 210,
+        "gust": 3.58
       },
-      sys: {
-        pod: 'n',
+      "visibility": 10000,
+      "pop": 0.7,
+      "rain": {
+        "3h": 0.49
       },
-      dt_txt: '2017-02-16 18:00:00',
+      "sys": {
+        "pod": "n"
+      },
+      "dt_txt": "2022-08-30 21:00:00"
     },
     {
-      dt: 1487278800,
-      main: {
-        temp: 272.78,
-        temp_min: 271.503,
-        temp_max: 272.78,
-        pressure: 969.32,
-        sea_level: 1044.14,
-        grnd_level: 969.32,
-        humidity: 80,
-        temp_kf: 1.28,
+      "dt": 1662292800,
+      "main": {
+        "temp": 294.93,
+        "feels_like": 294.83,
+        "temp_min": 294.93,
+        "temp_max": 294.93,
+        "pressure": 1018,
+        "sea_level": 1018,
+        "grnd_level": 935,
+        "humidity": 64,
+        "temp_kf": 0
       },
-      weather: [
+      "weather": [
         {
-          id: 800,
-          main: 'Clear',
-          description: 'clear sky',
-          icon: '01n',
-        },
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
       ],
-      clouds: {
-        all: 0,
-      },
-      wind: {
-        speed: 2.24,
-        deg: 205.502,
-      },
-      sys: {
-        pod: 'n',
-      },
-      dt_txt: '2017-02-16 21:00:00',
-    },
-    {
-      dt: 1487289600,
-      main: {
-        temp: 273.341,
-        temp_min: 273.341,
-        temp_max: 273.341,
-        pressure: 968.14,
-        sea_level: 1042.96,
-        grnd_level: 968.14,
-        humidity: 85,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 803,
-          main: 'Clouds',
-          description: 'broken clouds',
-          icon: '04n',
-        },
-      ],
-      clouds: {
-        all: 76,
-      },
-      wind: {
-        speed: 3.59,
-        deg: 224.003,
-      },
-      sys: {
-        pod: 'n',
-      },
-      dt_txt: '2017-02-17 00:00:00',
-    },
-    {
-      dt: 1487300400,
-      main: {
-        temp: 275.568,
-        temp_min: 275.568,
-        temp_max: 275.568,
-        pressure: 966.6,
-        sea_level: 1041.39,
-        grnd_level: 966.6,
-        humidity: 89,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 500,
-          main: 'Rain',
-          description: 'light rain',
-          icon: '10n',
-        },
-      ],
-      clouds: {
-        all: 76,
-      },
-      wind: {
-        speed: 3.77,
-        deg: 237.002,
-      },
-      rain: {
-        '3h': 0.32,
-      },
-      sys: {
-        pod: 'n',
-      },
-      dt_txt: '2017-02-17 03:00:00',
-    },
-    {
-      dt: 1487311200,
-      main: {
-        temp: 276.478,
-        temp_min: 276.478,
-        temp_max: 276.478,
-        pressure: 966.45,
-        sea_level: 1041.21,
-        grnd_level: 966.45,
-        humidity: 97,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 501,
-          main: 'Rain',
-          description: 'moderate rain',
-          icon: '10n',
-        },
-      ],
-      clouds: {
-        all: 92,
-      },
-      wind: {
-        speed: 3.81,
-        deg: 268.005,
-      },
-      rain: {
-        '3h': 4.9,
-      },
-      sys: {
-        pod: 'n',
-      },
-      dt_txt: '2017-02-17 06:00:00',
-    },
-    {
-      dt: 1487322000,
-      main: {
-        temp: 276.67,
-        temp_min: 276.67,
-        temp_max: 276.67,
-        pressure: 967.41,
-        sea_level: 1041.95,
-        grnd_level: 967.41,
-        humidity: 100,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 500,
-          main: 'Rain',
-          description: 'light rain',
-          icon: '10d',
-        },
-      ],
-      clouds: {
-        all: 64,
-      },
-      wind: {
-        speed: 2.6,
-        deg: 266.504,
-      },
-      rain: {
-        '3h': 1.37,
-      },
-      sys: {
-        pod: 'd',
-      },
-      dt_txt: '2017-02-17 09:00:00',
-    },
-    {
-      dt: 1487332800,
-      main: {
-        temp: 278.253,
-        temp_min: 278.253,
-        temp_max: 278.253,
-        pressure: 966.98,
-        sea_level: 1040.89,
-        grnd_level: 966.98,
-        humidity: 95,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 500,
-          main: 'Rain',
-          description: 'light rain',
-          icon: '10d',
-        },
-      ],
-      clouds: {
-        all: 92,
-      },
-      wind: {
-        speed: 3.17,
-        deg: 261.501,
-      },
-      rain: {
-        '3h': 0.12,
-      },
-      sys: {
-        pod: 'd',
-      },
-      dt_txt: '2017-02-17 12:00:00',
-    },
-    {
-      dt: 1487343600,
-      main: {
-        temp: 276.455,
-        temp_min: 276.455,
-        temp_max: 276.455,
-        pressure: 966.38,
-        sea_level: 1040.17,
-        grnd_level: 966.38,
-        humidity: 99,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 500,
-          main: 'Rain',
-          description: 'light rain',
-          icon: '10d',
-        },
-      ],
-      clouds: {
-        all: 92,
-      },
-      wind: {
-        speed: 3.21,
-        deg: 268.001,
-      },
-      rain: {
-        '3h': 2.12,
-      },
-      sys: {
-        pod: 'd',
-      },
-      dt_txt: '2017-02-17 15:00:00',
-    },
-    {
-      dt: 1487354400,
-      main: {
-        temp: 275.639,
-        temp_min: 275.639,
-        temp_max: 275.639,
-        pressure: 966.39,
-        sea_level: 1040.65,
-        grnd_level: 966.39,
-        humidity: 95,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 500,
-          main: 'Rain',
-          description: 'light rain',
-          icon: '10n',
-        },
-      ],
-      clouds: {
-        all: 88,
-      },
-      wind: {
-        speed: 3.17,
-        deg: 258.001,
-      },
-      rain: {
-        '3h': 0.7,
-      },
-      snow: {
-        '3h': 0.0775,
-      },
-      sys: {
-        pod: 'n',
-      },
-      dt_txt: '2017-02-17 18:00:00',
-    },
-    {
-      dt: 1487365200,
-      main: {
-        temp: 275.459,
-        temp_min: 275.459,
-        temp_max: 275.459,
-        pressure: 966.3,
-        sea_level: 1040.8,
-        grnd_level: 966.3,
-        humidity: 96,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 500,
-          main: 'Rain',
-          description: 'light rain',
-          icon: '10n',
-        },
-      ],
-      clouds: {
-        all: 88,
-      },
-      wind: {
-        speed: 3.71,
-        deg: 265.503,
-      },
-      rain: {
-        '3h': 1.16,
-      },
-      snow: {
-        '3h': 0.075,
-      },
-      sys: {
-        pod: 'n',
-      },
-      dt_txt: '2017-02-17 21:00:00',
-    },
-    {
-      dt: 1487376000,
-      main: {
-        temp: 275.035,
-        temp_min: 275.035,
-        temp_max: 275.035,
-        pressure: 966.43,
-        sea_level: 1041.02,
-        grnd_level: 966.43,
-        humidity: 99,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 500,
-          main: 'Rain',
-          description: 'light rain',
-          icon: '10n',
-        },
-      ],
-      clouds: {
-        all: 92,
-      },
-      wind: {
-        speed: 3.56,
-        deg: 273.5,
-      },
-      rain: {
-        '3h': 1.37,
-      },
-      snow: {
-        '3h': 0.1525,
-      },
-      sys: {
-        pod: 'n',
-      },
-      dt_txt: '2017-02-18 00:00:00',
-    },
-    {
-      dt: 1487386800,
-      main: {
-        temp: 274.965,
-        temp_min: 274.965,
-        temp_max: 274.965,
-        pressure: 966.36,
-        sea_level: 1041.17,
-        grnd_level: 966.36,
-        humidity: 97,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 500,
-          main: 'Rain',
-          description: 'light rain',
-          icon: '10n',
-        },
-      ],
-      clouds: {
-        all: 88,
-      },
-      wind: {
-        speed: 2.66,
-        deg: 285.502,
-      },
-      rain: {
-        '3h': 0.79,
-      },
-      snow: {
-        '3h': 0.52,
-      },
-      sys: {
-        pod: 'n',
-      },
-      dt_txt: '2017-02-18 03:00:00',
-    },
-    {
-      dt: 1487397600,
-      main: {
-        temp: 274.562,
-        temp_min: 274.562,
-        temp_max: 274.562,
-        pressure: 966.75,
-        sea_level: 1041.57,
-        grnd_level: 966.75,
-        humidity: 98,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 500,
-          main: 'Rain',
-          description: 'light rain',
-          icon: '10n',
-        },
-      ],
-      clouds: {
-        all: 88,
-      },
-      wind: {
-        speed: 1.46,
-        deg: 276.5,
-      },
-      rain: {
-        '3h': 0.08,
-      },
-      snow: {
-        '3h': 0.06,
-      },
-      sys: {
-        pod: 'n',
-      },
-      dt_txt: '2017-02-18 06:00:00',
-    },
-    {
-      dt: 1487408400,
-      main: {
-        temp: 275.648,
-        temp_min: 275.648,
-        temp_max: 275.648,
-        pressure: 967.21,
-        sea_level: 1041.74,
-        grnd_level: 967.21,
-        humidity: 99,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 500,
-          main: 'Rain',
-          description: 'light rain',
-          icon: '10d',
-        },
-      ],
-      clouds: {
-        all: 56,
-      },
-      wind: {
-        speed: 1.5,
-        deg: 251.008,
-      },
-      rain: {
-        '3h': 0.02,
-      },
-      snow: {
-        '3h': 0.03,
-      },
-      sys: {
-        pod: 'd',
-      },
-      dt_txt: '2017-02-18 09:00:00',
-    },
-    {
-      dt: 1487419200,
-      main: {
-        temp: 277.927,
-        temp_min: 277.927,
-        temp_max: 277.927,
-        pressure: 966.06,
-        sea_level: 1039.98,
-        grnd_level: 966.06,
-        humidity: 95,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 800,
-          main: 'Clear',
-          description: 'clear sky',
-          icon: '02d',
-        },
-      ],
-      clouds: {
-        all: 8,
-      },
-      wind: {
-        speed: 0.86,
-        deg: 244.004,
-      },
-      rain: {},
-      snow: {},
-      sys: {
-        pod: 'd',
-      },
-      dt_txt: '2017-02-18 12:00:00',
-    },
-    {
-      dt: 1487430000,
-      main: {
-        temp: 278.367,
-        temp_min: 278.367,
-        temp_max: 278.367,
-        pressure: 964.57,
-        sea_level: 1038.35,
-        grnd_level: 964.57,
-        humidity: 89,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 800,
-          main: 'Clear',
-          description: 'clear sky',
-          icon: '02d',
-        },
-      ],
-      clouds: {
-        all: 8,
-      },
-      wind: {
-        speed: 1.62,
-        deg: 79.5024,
-      },
-      rain: {},
-      snow: {},
-      sys: {
-        pod: 'd',
-      },
-      dt_txt: '2017-02-18 15:00:00',
-    },
-    {
-      dt: 1487440800,
-      main: {
-        temp: 273.797,
-        temp_min: 273.797,
-        temp_max: 273.797,
-        pressure: 964.13,
-        sea_level: 1038.48,
-        grnd_level: 964.13,
-        humidity: 91,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 800,
-          main: 'Clear',
-          description: 'clear sky',
-          icon: '01n',
-        },
-      ],
-      clouds: {
-        all: 0,
-      },
-      wind: {
-        speed: 2.42,
-        deg: 77.0026,
-      },
-      rain: {},
-      snow: {},
-      sys: {
-        pod: 'n',
-      },
-      dt_txt: '2017-02-18 18:00:00',
-    },
-    {
-      dt: 1487451600,
-      main: {
-        temp: 271.239,
-        temp_min: 271.239,
-        temp_max: 271.239,
-        pressure: 963.39,
-        sea_level: 1038.21,
-        grnd_level: 963.39,
-        humidity: 93,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 800,
-          main: 'Clear',
-          description: 'clear sky',
-          icon: '01n',
-        },
-      ],
-      clouds: {
-        all: 0,
-      },
-      wind: {
-        speed: 2.42,
-        deg: 95.5017,
-      },
-      rain: {},
-      snow: {},
-      sys: {
-        pod: 'n',
-      },
-      dt_txt: '2017-02-18 21:00:00',
-    },
-    {
-      dt: 1487462400,
-      main: {
-        temp: 269.553,
-        temp_min: 269.553,
-        temp_max: 269.553,
-        pressure: 962.39,
-        sea_level: 1037.44,
-        grnd_level: 962.39,
-        humidity: 92,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 800,
-          main: 'Clear',
-          description: 'clear sky',
-          icon: '01n',
-        },
-      ],
-      clouds: {
-        all: 0,
-      },
-      wind: {
-        speed: 1.96,
-        deg: 101.004,
-      },
-      rain: {},
-      snow: {},
-      sys: {
-        pod: 'n',
-      },
-      dt_txt: '2017-02-19 00:00:00',
-    },
-    {
-      dt: 1487473200,
-      main: {
-        temp: 268.198,
-        temp_min: 268.198,
-        temp_max: 268.198,
-        pressure: 961.28,
-        sea_level: 1036.51,
-        grnd_level: 961.28,
-        humidity: 84,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 800,
-          main: 'Clear',
-          description: 'clear sky',
-          icon: '01n',
-        },
-      ],
-      clouds: {
-        all: 0,
-      },
-      wind: {
-        speed: 1.06,
-        deg: 121.5,
-      },
-      rain: {},
-      snow: {},
-      sys: {
-        pod: 'n',
-      },
-      dt_txt: '2017-02-19 03:00:00',
-    },
-    {
-      dt: 1487484000,
-      main: {
-        temp: 267.295,
-        temp_min: 267.295,
-        temp_max: 267.295,
-        pressure: 961.16,
-        sea_level: 1036.45,
-        grnd_level: 961.16,
-        humidity: 86,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 800,
-          main: 'Clear',
-          description: 'clear sky',
-          icon: '01n',
-        },
-      ],
-      clouds: {
-        all: 0,
-      },
-      wind: {
-        speed: 1.17,
-        deg: 155.005,
-      },
-      rain: {},
-      snow: {},
-      sys: {
-        pod: 'n',
-      },
-      dt_txt: '2017-02-19 06:00:00',
-    },
-    {
-      dt: 1487494800,
-      main: {
-        temp: 272.956,
-        temp_min: 272.956,
-        temp_max: 272.956,
-        pressure: 962.03,
-        sea_level: 1036.85,
-        grnd_level: 962.03,
-        humidity: 84,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 800,
-          main: 'Clear',
-          description: 'clear sky',
-          icon: '01d',
-        },
-      ],
-      clouds: {
-        all: 0,
-      },
-      wind: {
-        speed: 1.66,
-        deg: 195.002,
-      },
-      rain: {},
-      snow: {},
-      sys: {
-        pod: 'd',
-      },
-      dt_txt: '2017-02-19 09:00:00',
-    },
-    {
-      dt: 1487505600,
-      main: {
-        temp: 277.422,
-        temp_min: 277.422,
-        temp_max: 277.422,
-        pressure: 962.23,
-        sea_level: 1036.06,
-        grnd_level: 962.23,
-        humidity: 89,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 800,
-          main: 'Clear',
-          description: 'clear sky',
-          icon: '01d',
-        },
-      ],
-      clouds: {
-        all: 0,
-      },
-      wind: {
-        speed: 1.32,
-        deg: 357.003,
-      },
-      rain: {},
-      snow: {},
-      sys: {
-        pod: 'd',
-      },
-      dt_txt: '2017-02-19 12:00:00',
-    },
-    {
-      dt: 1487516400,
-      main: {
-        temp: 277.984,
-        temp_min: 277.984,
-        temp_max: 277.984,
-        pressure: 962.15,
-        sea_level: 1035.86,
-        grnd_level: 962.15,
-        humidity: 87,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 800,
-          main: 'Clear',
-          description: 'clear sky',
-          icon: '01d',
-        },
-      ],
-      clouds: {
-        all: 0,
-      },
-      wind: {
-        speed: 1.58,
-        deg: 48.5031,
-      },
-      rain: {},
-      snow: {},
-      sys: {
-        pod: 'd',
-      },
-      dt_txt: '2017-02-19 15:00:00',
-    },
-    {
-      dt: 1487527200,
-      main: {
-        temp: 272.459,
-        temp_min: 272.459,
-        temp_max: 272.459,
-        pressure: 963.31,
-        sea_level: 1037.81,
-        grnd_level: 963.31,
-        humidity: 90,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 800,
-          main: 'Clear',
-          description: 'clear sky',
-          icon: '01n',
-        },
-      ],
-      clouds: {
-        all: 0,
-      },
-      wind: {
-        speed: 1.16,
-        deg: 75.5042,
-      },
-      rain: {},
-      snow: {},
-      sys: {
-        pod: 'n',
-      },
-      dt_txt: '2017-02-19 18:00:00',
-    },
-    {
-      dt: 1487538000,
-      main: {
-        temp: 269.473,
-        temp_min: 269.473,
-        temp_max: 269.473,
-        pressure: 964.65,
-        sea_level: 1039.76,
-        grnd_level: 964.65,
-        humidity: 83,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 800,
-          main: 'Clear',
-          description: 'clear sky',
-          icon: '01n',
-        },
-      ],
-      clouds: {
-        all: 0,
-      },
-      wind: {
-        speed: 1.12,
-        deg: 174.002,
-      },
-      rain: {},
-      snow: {},
-      sys: {
-        pod: 'n',
-      },
-      dt_txt: '2017-02-19 21:00:00',
-    },
-    {
-      dt: 1487548800,
-      main: {
-        temp: 268.793,
-        temp_min: 268.793,
-        temp_max: 268.793,
-        pressure: 965.92,
-        sea_level: 1041.32,
-        grnd_level: 965.92,
-        humidity: 80,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 800,
-          main: 'Clear',
-          description: 'clear sky',
-          icon: '01n',
-        },
-      ],
-      clouds: {
-        all: 0,
-      },
-      wind: {
-        speed: 2.11,
-        deg: 207.502,
-      },
-      rain: {},
-      snow: {},
-      sys: {
-        pod: 'n',
-      },
-      dt_txt: '2017-02-20 00:00:00',
-    },
-    {
-      dt: 1487559600,
-      main: {
-        temp: 268.106,
-        temp_min: 268.106,
-        temp_max: 268.106,
-        pressure: 966.4,
-        sea_level: 1042.18,
-        grnd_level: 966.4,
-        humidity: 85,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 800,
-          main: 'Clear',
-          description: 'clear sky',
-          icon: '01n',
-        },
-      ],
-      clouds: {
-        all: 0,
-      },
-      wind: {
-        speed: 1.67,
-        deg: 191.001,
-      },
-      rain: {},
-      snow: {},
-      sys: {
-        pod: 'n',
-      },
-      dt_txt: '2017-02-20 03:00:00',
-    },
-    {
-      dt: 1487570400,
-      main: {
-        temp: 267.655,
-        temp_min: 267.655,
-        temp_max: 267.655,
-        pressure: 967.4,
-        sea_level: 1043.43,
-        grnd_level: 967.4,
-        humidity: 84,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 800,
-          main: 'Clear',
-          description: 'clear sky',
-          icon: '01n',
-        },
-      ],
-      clouds: {
-        all: 0,
-      },
-      wind: {
-        speed: 1.61,
-        deg: 194.001,
-      },
-      rain: {},
-      snow: {},
-      sys: {
-        pod: 'n',
-      },
-      dt_txt: '2017-02-20 06:00:00',
-    },
-    {
-      dt: 1487581200,
-      main: {
-        temp: 273.75,
-        temp_min: 273.75,
-        temp_max: 273.75,
-        pressure: 968.84,
-        sea_level: 1044.23,
-        grnd_level: 968.84,
-        humidity: 83,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 800,
-          main: 'Clear',
-          description: 'clear sky',
-          icon: '01d',
-        },
-      ],
-      clouds: {
-        all: 0,
-      },
-      wind: {
-        speed: 2.49,
-        deg: 208.5,
-      },
-      rain: {},
-      snow: {},
-      sys: {
-        pod: 'd',
-      },
-      dt_txt: '2017-02-20 09:00:00',
-    },
-    {
-      dt: 1487592000,
-      main: {
-        temp: 279.302,
-        temp_min: 279.302,
-        temp_max: 279.302,
-        pressure: 968.37,
-        sea_level: 1042.52,
-        grnd_level: 968.37,
-        humidity: 83,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 800,
-          main: 'Clear',
-          description: 'clear sky',
-          icon: '01d',
-        },
-      ],
-      clouds: {
-        all: 0,
-      },
-      wind: {
-        speed: 2.46,
-        deg: 252.001,
-      },
-      rain: {},
-      snow: {},
-      sys: {
-        pod: 'd',
-      },
-      dt_txt: '2017-02-20 12:00:00',
-    },
-    {
-      dt: 1487602800,
-      main: {
-        temp: 279.343,
-        temp_min: 279.343,
-        temp_max: 279.343,
-        pressure: 967.9,
-        sea_level: 1041.64,
-        grnd_level: 967.9,
-        humidity: 81,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 800,
-          main: 'Clear',
-          description: 'clear sky',
-          icon: '01d',
-        },
-      ],
-      clouds: {
-        all: 0,
-      },
-      wind: {
-        speed: 3.21,
-        deg: 268.001,
-      },
-      rain: {},
-      snow: {},
-      sys: {
-        pod: 'd',
-      },
-      dt_txt: '2017-02-20 15:00:00',
-    },
-    {
-      dt: 1487613600,
-      main: {
-        temp: 274.443,
-        temp_min: 274.443,
-        temp_max: 274.443,
-        pressure: 968.19,
-        sea_level: 1042.66,
-        grnd_level: 968.19,
-        humidity: 88,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 801,
-          main: 'Clouds',
-          description: 'few clouds',
-          icon: '02n',
-        },
-      ],
-      clouds: {
-        all: 24,
-      },
-      wind: {
-        speed: 3.27,
-        deg: 257.501,
-      },
-      rain: {},
-      snow: {},
-      sys: {
-        pod: 'n',
-      },
-      dt_txt: '2017-02-20 18:00:00',
-    },
-    {
-      dt: 1487624400,
-      main: {
-        temp: 272.424,
-        temp_min: 272.424,
-        temp_max: 272.424,
-        pressure: 968.38,
-        sea_level: 1043.17,
-        grnd_level: 968.38,
-        humidity: 85,
-        temp_kf: 0,
-      },
-      weather: [
-        {
-          id: 801,
-          main: 'Clouds',
-          description: 'few clouds',
-          icon: '02n',
-        },
-      ],
-      clouds: {
-        all: 20,
-      },
-      wind: {
-        speed: 3.57,
-        deg: 255.503,
-      },
-      rain: {},
-      snow: {},
-      sys: {
-        pod: 'n',
-      },
-      dt_txt: '2017-02-20 21:00:00',
-    },
+      "clouds": {
+        "all": 88
+      },
+      "wind": {
+        "speed": 1.14,
+        "deg": 17,
+        "gust": 1.57
+      },
+      "visibility": 10000,
+      "pop": 0,
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2022-09-04 12:00:00"
+    }
   ],
-  city: {
-    id: 6940463,
-    name: 'Altstadt',
-    coord: {
-      lat: 48.137,
-      lon: 11.5752,
+  "city": {
+    "id": 3163858,
+    "name": "Zocca",
+    "coord": {
+      "lat": 44.34,
+      "lon": 10.99
     },
-    country: 'none',
-  },
+    "country": "IT",
+    "population": 4593,
+    "timezone": 7200,
+    "sunrise": 1661834187,
+    "sunset": 1661882248
+  }
 }
 
 export type ThreeHourResponse = typeof data


### PR DESCRIPTION
I dont know if the API Changed, but there were a few Types missing in the original TypeScript-Types for CurrentResponse and ThreeHourResponse. I realized it while trying to get the probability if its gonna rain (list.pop). 

Instead of using the example response from the url you provided, i used the example response from their documentation (https://openweathermap.org/forecast5) 

P.S.: i really like the wrapper and id like to update the types in the future. And i dont know if you still maintain this package. If you stopped mainting id like to ask if i may take over, because its afaik the only wrapper with ts-support and its in general a neat package but not updated.

Thanks